### PR TITLE
Fix two links on "usage" page

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -12,7 +12,7 @@ See <a href="/download.html">Download</a> for how to download Vampire.
 <h2>Manual</h2>
 <p>
 Vampire manual is not finished yet.
-While there is no manual, you can use the <a href="http://www.cse.chalmers.se/~laurako/pub/CAV13_Kovacs.pdf">CAV 2013 tutorial paper</a>, which describes main features of Vampire and some of its options.
+While there is no manual, you can use the <a href="https://publik.tuwien.ac.at/files/PubDat_225994.pdf">CAV 2013 tutorial paper</a>, which describes main features of Vampire and some of its options.
 </p>
 
 <h2>Basic Usage</h2>

--- a/usage.html
+++ b/usage.html
@@ -17,7 +17,7 @@ While there is no manual, you can use the <a href="http://www.cse.chalmers.se/~l
 
 <h2>Basic Usage</h2>
 <p>
-The most basic usage of Vampire is to save your problem in <a href="http://www.cs.miami.edu/~tptp/">TPTP</a> format and run
+The most basic usage of Vampire is to save your problem in <a href="https://www.tptp.org/">TPTP</a> format and run
 <code>
 vampire problem.p 
 </code>


### PR DESCRIPTION
The TPTP site was moved to its own dedicated page at some point. Also, the tutorial paper link 404'ed.