### PR TITLE
Update SMT{LIB, COMP} and CASC links

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -37,11 +37,11 @@ If you think the problem is satisfiable then you can also run
 <code>
 vampire --mode casc_sat -t 300 problem.p 
 </code>
-which will use a set of strategies suited to satisfiable problems (as entered into the most recent <a href="http://www.cs.miami.edu/~tptp/CASC/">CASC</a> competition).
+which will use a set of strategies suited to satisfiable problems (as entered into the most recent <a href="https://www.tptp.org/CASC/">CASC</a> competition).
 </p>
 
 <p>
-Finally, if your problem is in <a href="http://smtlib.cs.uiowa.edu/">SMT-LIB</a> format you can run
+Finally, if your problem is in <a href="https://smtlib.cs.uiowa.edu/">SMT-LIB</a> format you can run
 <code>
 vampire --input_syntax smtlib2 problem.smt2 
 </code>
@@ -49,7 +49,7 @@ to specify a different input language, or
 <code>
 vampire --mode smtcomp problem.p 
 </code>
-to use the latest <a href="http://smtcomp.sourceforge.net/">SMT-COMP</a> schedule, which automatically selects the appropriate input language.
+to use the latest <a href="https://smt-comp.github.io/">SMT-COMP</a> schedule, which automatically selects the appropriate input language.
 </p>
 
 <p>


### PR DESCRIPTION
- Updated SMTCOMP (outdated) and CASC (broken) links to point to their new locations
- Updated SMTLIB link to be `https` for consistency while I was there 