### PR TITLE
Fix `portfolio` command

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -55,7 +55,7 @@ to use the latest <a href="http://smtcomp.sourceforge.net/">SMT-COMP</a> schedul
 <p>
 Note that all of these competition modes are really shortcuts for other combinations e.g. casc mode is a shortcut for
 <code>
-vampire --mode portflio --schedule casc -t 300s -p tptp
+vampire --mode portfolio --schedule casc -t 300s -p tptp
 </code>
 
 <h2>Options and More Advanced Usage</h2>


### PR DESCRIPTION
Fixed spelling of `portfolio` in the usage command shown for it.

`portflio` --> `portfolio`

This caused the command to not work before.